### PR TITLE
Fix asset loading for ISAT/SA3AP

### DIFF
--- a/www/modloader/_oneloader_configuration.js
+++ b/www/modloader/_oneloader_configuration.js
@@ -3,8 +3,8 @@ if (window.nw.App.argv[0] !== "test") {
     const MAX_MANIFEST_VERSION = 1;
     const ID_BLACKLIST = ["gomori"];
     const EXTENSION_RULES = {
-        "png": { "encrypt": "rpgmaker", "target_extension": "rpgmvp" },
-        "ogg": { "encrypt": "rpgmaker", "target_extension": "rpgmvo" }
+        "png": { "encrypt": "rpgmaker", "target_extension": "png" },
+        "ogg": { "encrypt": "rpgmaker", "target_extension": "ogg" }
     };
 
     let LANGUAGE = "en";


### PR DESCRIPTION
These games directly use OGG and PNG files, not rpgmvo/rpgmvp, so the mod loader should load them as such so that asset mods can work.